### PR TITLE
feat(smtp): encrypt stored SMTP passwords at rest

### DIFF
--- a/src/api/smtp/createSmtpConfig.ts
+++ b/src/api/smtp/createSmtpConfig.ts
@@ -1,5 +1,6 @@
 import { db } from '@/db/client';
 import { smtpConfigTable } from '@/db/tables/smtpConfigTable';
+import { encryptStoredSmtpPassword } from '@/lib/smtpPasswordCrypto';
 import { smtpCreateFormSchema } from '@/routes/_auth/app/settings/-lib/settings-automations-tab/smtpUpsertFormSchemas';
 import {
 	createMutationOptions,
@@ -33,7 +34,7 @@ const createSmtpConfigServerFn = createServerFn({
 				port: form.port,
 				security: form.security,
 				username: form.username,
-				password: form.password,
+				password: encryptStoredSmtpPassword(form.password),
 				fromName: form.fromName,
 				fromEmail: form.fromEmail,
 			});

--- a/src/api/smtp/updateSmtpConfig.ts
+++ b/src/api/smtp/updateSmtpConfig.ts
@@ -1,5 +1,6 @@
 import { db } from '@/db/client';
 import { smtpConfigTable } from '@/db/tables/smtpConfigTable';
+import { encryptStoredSmtpPassword } from '@/lib/smtpPasswordCrypto';
 import { smtpUpdateFormSchema } from '@/routes/_auth/app/settings/-lib/settings-automations-tab/smtpUpsertFormSchemas';
 import { getServerT } from '@/utils/languageUtils';
 import {
@@ -62,7 +63,7 @@ const updateSmtpConfigServerFn = createServerFn({
 			};
 
 			if (form.password) {
-				updateData.password = form.password;
+				updateData.password = encryptStoredSmtpPassword(form.password);
 			}
 
 			await db

--- a/src/lib/smtpPasswordCrypto.ts
+++ b/src/lib/smtpPasswordCrypto.ts
@@ -1,0 +1,73 @@
+import '@tanstack/react-start/server-only';
+
+import {
+	createCipheriv,
+	createDecipheriv,
+	hkdfSync,
+	randomBytes,
+} from 'node:crypto';
+
+import { envServer } from '@/lib/envServer';
+
+/** ASCII prefix marking AES-256-GCM ciphertext persisted in DB (v1) */
+const STORAGE_PREFIX = 'inv1_aes256_gcm$:';
+
+/** HKDF label — stable across deploys; changing it invalidates stored ciphertext */
+const HKDF_INFO = Buffer.from('invoiced:smtp-password:v1', 'utf8');
+
+function smtpPasswordDerivedKey(): Buffer {
+	const rawKey = hkdfSync(
+		'sha256',
+		Buffer.from(envServer.BETTER_AUTH_SECRET, 'utf8'),
+		Buffer.alloc(0),
+		HKDF_INFO,
+		32,
+	);
+	return Buffer.from(rawKey);
+}
+
+export function encryptStoredSmtpPassword(plainPassword: string): string {
+	const key = smtpPasswordDerivedKey();
+	const iv = randomBytes(12);
+	const cipher = createCipheriv('aes-256-gcm', key, iv);
+	const ciphertext = Buffer.concat([
+		cipher.update(plainPassword, 'utf8'),
+		cipher.final(),
+	]);
+	const authTag = cipher.getAuthTag();
+	const payload = Buffer.concat([iv, authTag, ciphertext]);
+	return `${STORAGE_PREFIX}${payload.toString('base64url')}`;
+}
+
+/**
+ * Produces plain password for SMTP transport. Rows written before encryption
+ * (plaintext) are returned as-is. Call this only on the server.
+ *
+ * @public For SMTP transport when invoice email sending is implemented.
+ */
+export function decryptStoredSmtpPasswordForUse(
+	storedPassword: string,
+): string {
+	if (!storedPassword.startsWith(STORAGE_PREFIX)) {
+		return storedPassword;
+	}
+
+	const raw = Buffer.from(
+		storedPassword.slice(STORAGE_PREFIX.length),
+		'base64url',
+	);
+	if (raw.length < 12 + 16) {
+		throw new Error('Invalid encrypted SMTP password payload');
+	}
+
+	const iv = raw.subarray(0, 12);
+	const authTag = raw.subarray(12, 28);
+	const ciphertext = raw.subarray(28);
+	const key = smtpPasswordDerivedKey();
+	const decipher = createDecipheriv('aes-256-gcm', key, iv);
+	decipher.setAuthTag(authTag);
+	return Buffer.concat([
+		decipher.update(ciphertext),
+		decipher.final(),
+	]).toString('utf8');
+}


### PR DESCRIPTION
Persist AES-256-GCM ciphertext keyed via HKDF(BETTER_AUTH_SECRET) and keep decrypt helper for future mail transport.