### PR TITLE
refactor(i18n): use isomorphic getT instead of getServerT and transla…

### DIFF
--- a/src/api/auth/ensureAuthSession.ts
+++ b/src/api/auth/ensureAuthSession.ts
@@ -3,7 +3,6 @@ import { createSuccessResponse } from '@/utils/serverFnsUtils';
 import { redirect } from '@tanstack/react-router';
 import { createServerFn } from '@tanstack/react-start';
 import { getRequestHeaders } from '@tanstack/react-start/server';
-import { getLanguage } from '@/utils/languageUtils';
 
 export const ensureAuthSessionServerFn = createServerFn({
 	method: 'GET',
@@ -15,6 +14,5 @@ export const ensureAuthSessionServerFn = createServerFn({
 		throw redirect({ to: '/', replace: true });
 	}
 
-	const language = getLanguage();
-	return createSuccessResponse({ data: { ...session, language } });
+	return createSuccessResponse({ data: session });
 });

--- a/src/api/company/updateCompany.ts
+++ b/src/api/company/updateCompany.ts
@@ -1,7 +1,8 @@
 import { db } from '@/db/client';
 import { companyAddressTable } from '@/db/tables/companyAddressTable';
 import { companyTable } from '@/db/tables/companyTable';
-import { eq } from 'drizzle-orm';
+import { companyUpsertFormSchema } from '@/routes/_auth/app/settings/-lib/settings-company-tab/companyUpsertFormSchemas';
+import { getT } from '@/utils/languageUtils';
 import {
 	createMutationOptions,
 	invalidateOnSuccess,
@@ -11,11 +12,10 @@ import {
 	createSuccessResponse,
 } from '@/utils/serverFnsUtils';
 import { createServerFn } from '@tanstack/react-start';
+import { eq } from 'drizzle-orm';
 import z from 'zod';
-import { companyQueryKeys } from './companyApiUtils';
 import { sessionMiddleware } from '../sessionMiddleware';
-import { companyUpsertFormSchema } from '@/routes/_auth/app/settings/-lib/settings-company-tab/companyUpsertFormSchemas';
-import { getServerT } from '@/utils/languageUtils';
+import { companyQueryKeys } from './companyApiUtils';
 
 const updateCompanyParams = z.object({
 	form: companyUpsertFormSchema,
@@ -27,9 +27,9 @@ const updateCompanyServerFn = createServerFn({
 })
 	.middleware([sessionMiddleware])
 	.inputValidator(updateCompanyParams)
-	.handler(async ({ data: { form }, context: { user, language } }) => {
+	.handler(async ({ data: { form }, context: { user } }) => {
 		try {
-			const t = getServerT(language);
+			const t = getT();
 
 			const currentCompany = await db.query.companyTable.findFirst({
 				where: {

--- a/src/api/contract/createContract.ts
+++ b/src/api/contract/createContract.ts
@@ -1,7 +1,7 @@
+import { invoiceConfigurationPersistSchema } from '@/components/invoice-configuration-form/invoiceConfigurationFormSchemas';
 import { db } from '@/db/client';
 import { contractsUpsertFormSchema } from '@/routes/_auth/app/contracts/-lib/contracts-upsert-form/contractsUpsertFormSchemas';
-import { invoiceConfigurationPersistSchema } from '@/components/invoice-configuration-form/invoiceConfigurationFormSchemas';
-import { getServerT } from '@/utils/languageUtils';
+import { getT } from '@/utils/languageUtils';
 import { createMutationOptions } from '@/utils/queryOptionsUtils';
 import {
 	createErrorResponse,
@@ -27,12 +27,9 @@ const createContractServerFn = createServerFn({
 	.middleware([sessionMiddleware])
 	.inputValidator(createContractParams)
 	.handler(
-		async ({
-			data: { form, invoiceConfiguration },
-			context: { user, language },
-		}) => {
+		async ({ data: { form, invoiceConfiguration }, context: { user } }) => {
 			try {
-				const t = getServerT(language);
+				const t = getT();
 
 				const { contractId } = await db.transaction(async (tx) => {
 					await setupInvoiceConfiguration({

--- a/src/api/contract/deleteContract.ts
+++ b/src/api/contract/deleteContract.ts
@@ -1,6 +1,6 @@
 import { db } from '@/db/client';
 import { contractTable } from '@/db/tables/contractTable';
-import { getServerT } from '@/utils/languageUtils';
+import { getT } from '@/utils/languageUtils';
 import {
 	createMutationOptions,
 	invalidateOnSuccess,
@@ -27,9 +27,9 @@ const deleteContractServerFn = createServerFn({
 })
 	.middleware([sessionMiddleware])
 	.inputValidator(deleteContractParams)
-	.handler(async ({ data, context: { user, language } }) => {
+	.handler(async ({ data, context: { user } }) => {
 		try {
-			const t = getServerT(language);
+			const t = getT();
 
 			const { rowsAffected } = await db
 				.delete(contractTable)

--- a/src/api/contract/getEditContract.ts
+++ b/src/api/contract/getEditContract.ts
@@ -1,5 +1,5 @@
 import { db } from '@/db/client';
-import { getServerT } from '@/utils/languageUtils';
+import { getT } from '@/utils/languageUtils';
 import { createQueryOptions } from '@/utils/queryOptionsUtils';
 import {
 	createErrorResponse,
@@ -21,9 +21,9 @@ const getEditContractServerFn = createServerFn({
 })
 	.middleware([sessionMiddleware])
 	.inputValidator(getEditContractParams)
-	.handler(async ({ data, context: { user, language } }) => {
+	.handler(async ({ data, context: { user } }) => {
 		try {
-			const t = getServerT(language);
+			const t = getT();
 
 			const contract = await db.query.contractTable.findFirst({
 				where: {

--- a/src/api/contract/updateContract.ts
+++ b/src/api/contract/updateContract.ts
@@ -1,7 +1,7 @@
 import { db } from '@/db/client';
 import { contractsUpsertFormSchema } from '@/routes/_auth/app/contracts/-lib/contracts-upsert-form/contractsUpsertFormSchemas';
 import { invoiceConfigurationPersistSchema } from '@/components/invoice-configuration-form/invoiceConfigurationFormSchemas';
-import { getServerT } from '@/utils/languageUtils';
+import { getT } from '@/utils/languageUtils';
 import { createMutationOptions } from '@/utils/queryOptionsUtils';
 import {
 	createErrorResponse,
@@ -31,10 +31,10 @@ const updateContractServerFn = createServerFn({
 	.handler(
 		async ({
 			data: { editId, form, invoiceConfiguration },
-			context: { user, language },
+			context: { user },
 		}) => {
 			try {
-				const t = getServerT(language);
+				const t = getT();
 
 				await db.transaction(async (tx) => {
 					const contract = await tx.query.contractTable.findFirst({

--- a/src/api/email-template/createEmailTemplate.ts
+++ b/src/api/email-template/createEmailTemplate.ts
@@ -10,7 +10,7 @@ import {
 	HTTP_STATUS_CODES,
 	ServerError,
 } from '@/utils/serverFnsUtils';
-import { getServerT } from '@/utils/languageUtils';
+import { getT } from '@/utils/languageUtils';
 import { createServerFn } from '@tanstack/react-start';
 import z from 'zod';
 import { sessionMiddleware } from '../sessionMiddleware';
@@ -28,9 +28,9 @@ const createEmailTemplateServerFn = createServerFn({
 })
 	.middleware([sessionMiddleware])
 	.inputValidator(createEmailTemplateParams)
-	.handler(async ({ data: { form }, context: { user, language } }) => {
+	.handler(async ({ data: { form }, context: { user } }) => {
 		try {
-			const t = getServerT(language);
+			const t = getT();
 
 			const [createdTemplate] = await db
 				.insert(emailTemplateTable)

--- a/src/api/email-template/deleteEmailTemplate.ts
+++ b/src/api/email-template/deleteEmailTemplate.ts
@@ -4,7 +4,7 @@ import {
 	createMutationOptions,
 	invalidateOnSuccess,
 } from '@/utils/queryOptionsUtils';
-import { getServerT } from '@/utils/languageUtils';
+import { getT } from '@/utils/languageUtils';
 import {
 	createErrorResponse,
 	createSuccessResponse,
@@ -27,8 +27,9 @@ const deleteEmailTemplateServerFn = createServerFn({
 })
 	.middleware([sessionMiddleware])
 	.inputValidator(deleteEmailTemplateParams)
-	.handler(async ({ data, context: { user, language } }) => {
-		const t = getServerT(language);
+	.handler(async ({ data, context: { user } }) => {
+		const t = getT();
+
 		try {
 			await db
 				.delete(emailTemplateTable)

--- a/src/api/email-template/duplicateEmailTemplate.ts
+++ b/src/api/email-template/duplicateEmailTemplate.ts
@@ -1,7 +1,7 @@
 import z from 'zod';
 import { sessionMiddleware } from '../sessionMiddleware';
 import { createServerFn } from '@tanstack/react-start';
-import { getServerT } from '@/utils/languageUtils';
+import { getT } from '@/utils/languageUtils';
 import {
 	createErrorResponse,
 	createSuccessResponse,
@@ -26,9 +26,9 @@ const duplicateEmailTemplateServerFn = createServerFn({
 })
 	.middleware([sessionMiddleware])
 	.inputValidator(duplicateEmailTemplateParams)
-	.handler(async ({ data: { editId }, context: { user, language } }) => {
+	.handler(async ({ data: { editId }, context: { user } }) => {
 		try {
-			const t = getServerT(language);
+			const t = getT();
 
 			const baseEmailTemplate = await db.query.emailTemplateTable.findFirst({
 				where: {

--- a/src/api/email-template/getEditEmailTemplate.ts
+++ b/src/api/email-template/getEditEmailTemplate.ts
@@ -1,7 +1,7 @@
 import { createServerFn } from '@tanstack/react-start';
 import z from 'zod';
 import { sessionMiddleware } from '../sessionMiddleware';
-import { getServerT } from '@/utils/languageUtils';
+import { getT } from '@/utils/languageUtils';
 import { db } from '@/db/client';
 import {
 	createErrorResponse,
@@ -23,9 +23,9 @@ const getEditEmailTemplateServerFn = createServerFn({
 })
 	.middleware([sessionMiddleware])
 	.inputValidator(getEditEmailTemplateParams)
-	.handler(async ({ data, context: { user, language } }) => {
+	.handler(async ({ data, context: { user } }) => {
 		try {
-			const t = getServerT(language);
+			const t = getT();
 
 			const emailTemplate = await db.query.emailTemplateTable.findFirst({
 				where: {

--- a/src/api/email-template/updateEmailTemplate.ts
+++ b/src/api/email-template/updateEmailTemplate.ts
@@ -1,7 +1,7 @@
 import { db } from '@/db/client';
 import { emailTemplateTable } from '@/db/tables/emailTemplateTable';
 import { emailTemplateUpsertFormSchema } from '@/routes/_auth/app/settings/-lib/settings-automations-tab/emailTemplateUpsertFormSchema';
-import { getServerT } from '@/utils/languageUtils';
+import { getT } from '@/utils/languageUtils';
 import {
 	createMutationOptions,
 	invalidateOnSuccess,
@@ -28,9 +28,9 @@ const updateEmailTemplateServerFn = createServerFn({
 })
 	.middleware([sessionMiddleware])
 	.inputValidator(updateEmailTemplateParams)
-	.handler(async ({ data: { form, editId }, context: { user, language } }) => {
+	.handler(async ({ data: { form, editId }, context: { user } }) => {
 		try {
-			const t = getServerT(language);
+			const t = getT();
 
 			const currentTemplate = await db.query.emailTemplateTable.findFirst({
 				where: {

--- a/src/api/invoice-configuration/updateInvoiceConfiguration.ts
+++ b/src/api/invoice-configuration/updateInvoiceConfiguration.ts
@@ -14,7 +14,7 @@ import {
 import { createServerFn } from '@tanstack/react-start';
 import { eq } from 'drizzle-orm';
 import z from 'zod';
-import { getServerT } from '@/utils/languageUtils';
+import { getT } from '@/utils/languageUtils';
 import { sessionMiddleware } from '../sessionMiddleware';
 import { invoiceConfigurationQueryKeys } from './invoiceConfigurationApiUtils';
 
@@ -30,9 +30,9 @@ const updateInvoiceConfigurationServerFn = createServerFn({
 })
 	.middleware([sessionMiddleware])
 	.inputValidator(updateInvoiceConfigurationParams)
-	.handler(async ({ data: { form }, context: { user, language } }) => {
+	.handler(async ({ data: { form }, context: { user } }) => {
 		try {
-			const t = getServerT(language);
+			const t = getT();
 
 			const existing = await db.query.invoiceConfigurationTable.findFirst({
 				where: {

--- a/src/api/invoice/createInvoice.ts
+++ b/src/api/invoice/createInvoice.ts
@@ -8,7 +8,7 @@ import { invoiceConfigurationSnapshotTable } from '@/db/tables/invoiceConfigurat
 import { invoiceConfigurationTable } from '@/db/tables/invoiceConfigurationTable';
 import { invoiceItemsTable } from '@/db/tables/invoiceItemsTable';
 import { invoiceTable } from '@/db/tables/invoiceTable';
-import { getServerT } from '@/utils/languageUtils';
+import { getT } from '@/utils/languageUtils';
 import {
 	createMutationOptions,
 	invalidateOnSuccess,
@@ -41,9 +41,10 @@ const createInvoiceServerFn = createServerFn({
 })
 	.middleware([sessionMiddleware])
 	.inputValidator(createInvoiceParams)
-	.handler(async ({ data, context: { user, language } }) => {
+	.handler(async ({ data, context: { user } }) => {
 		try {
-			const t = getServerT(language);
+			const t = getT();
+
 			const { form, contractId } = data;
 
 			const invoice = await db.transaction(async (tx) => {

--- a/src/api/invoice/deleteInvoice.ts
+++ b/src/api/invoice/deleteInvoice.ts
@@ -14,7 +14,7 @@ import { and, eq } from 'drizzle-orm';
 import { z } from 'zod';
 import { sessionMiddleware } from '../sessionMiddleware';
 import { invoiceQueryKeys } from './invoiceApiUtils';
-import { getServerT } from '@/utils/languageUtils';
+import { getT } from '@/utils/languageUtils';
 
 const deleteInvoiceParams = z.object({
 	id: z.string(),
@@ -27,9 +27,10 @@ const deleteInvoiceServerFn = createServerFn({
 })
 	.middleware([sessionMiddleware])
 	.inputValidator(deleteInvoiceParams)
-	.handler(async ({ data, context: { user, language } }) => {
+	.handler(async ({ data, context: { user } }) => {
 		try {
-			const t = getServerT(language);
+			const t = getT();
+
 			const { id } = data;
 
 			const [invoice] = await db

--- a/src/api/invoice/sendInvoiceToAccounting.ts
+++ b/src/api/invoice/sendInvoiceToAccounting.ts
@@ -10,7 +10,7 @@ import {
 	createSuccessResponse,
 	ServerError,
 } from '@/utils/serverFnsUtils';
-import { getServerT } from '@/utils/languageUtils';
+import { getT } from '@/utils/languageUtils';
 import { createServerFn } from '@tanstack/react-start';
 import { z } from 'zod';
 import { sessionMiddleware } from '../sessionMiddleware';
@@ -40,8 +40,9 @@ const sendInvoiceToAccountingServerFn = createServerFn({
 })
 	.middleware([sessionMiddleware])
 	.inputValidator(sendInvoiceToAccountingParams)
-	.handler(async ({ data, context: { user, language } }) => {
-		const t = getServerT(language);
+	.handler(async ({ data, context: { user } }) => {
+		const t = getT();
+
 		try {
 			const { invoiceId } = data;
 

--- a/src/api/user/updateUserAccount.ts
+++ b/src/api/user/updateUserAccount.ts
@@ -1,7 +1,7 @@
 import { accountFormSchema } from '@/routes/_auth/app/settings/-lib/settings-account-tab/accountFormSchemas';
 import { db } from '@/db/client';
 import { userTable } from '@/db/tables/userTable';
-import { getServerT } from '@/utils/languageUtils';
+import { getT } from '@/utils/languageUtils';
 import {
 	createMutationOptions,
 	invalidateOnSuccess,
@@ -25,9 +25,9 @@ const updateUserAccountServerFn = createServerFn({
 })
 	.middleware([sessionMiddleware])
 	.inputValidator(updateUserAccountParams)
-	.handler(async ({ data, context: { user, language } }) => {
+	.handler(async ({ data, context: { user } }) => {
 		try {
-			const t = getServerT(language);
+			const t = getT();
 
 			await db
 				.update(userTable)

--- a/src/components/invoice-configuration-form/invoiceConfigurationFormSchemas.ts
+++ b/src/components/invoice-configuration-form/invoiceConfigurationFormSchemas.ts
@@ -1,5 +1,4 @@
-import { translate } from '@/translations/translate';
-import { getLanguage } from '@/utils/languageUtils';
+import { getT } from '@/utils/languageUtils';
 import z from 'zod';
 
 const invoiceNumberingModeSchema = z.enum(['new', 'existing']);
@@ -27,10 +26,12 @@ export const invoiceConfigurationFormSchema = invoiceConfigurationPersistSchema
 			data.invoiceNumberingMode === 'existing' &&
 			data.lastInvoiceNumber < 1
 		) {
+			const t = getT();
+
 			ctx.addIssue({
 				code: 'custom',
 				path: ['lastInvoiceNumber'],
-				message: translate(getLanguage(), 'validation.minNumber', {
+				message: t('validation.minNumber', {
 					minimum: 1,
 				}),
 			});

--- a/src/components/invoice-creation-drawer/invoiceCreationFormSchemas.ts
+++ b/src/components/invoice-creation-drawer/invoiceCreationFormSchemas.ts
@@ -1,6 +1,5 @@
 import type { GetContractsResponse } from '@/api/contract/getContracts';
-import { translate } from '@/translations/translate';
-import { getLanguage } from '@/utils/languageUtils';
+import { getT } from '@/utils/languageUtils';
 import z from 'zod';
 import { getClosestFutureRecurrenceItem, getRecurrenceItemDate } from './utils';
 
@@ -24,13 +23,12 @@ export const invoiceCreationFormSchema = z
 		}
 
 		if (data.items.length === 0) {
+			const t = getT();
+
 			ctx.addIssue({
 				code: 'custom',
 				path: ['items'],
-				message: translate(
-					getLanguage(),
-					'invoices.creation.validation.itemsRequiredInCustomMode',
-				),
+				message: t('invoices.creation.validation.itemsRequiredInCustomMode'),
 			});
 		}
 	});

--- a/src/hooks/use-language/useSyncZodErrorMap.ts
+++ b/src/hooks/use-language/useSyncZodErrorMap.ts
@@ -1,11 +1,8 @@
-import { useEffect } from 'react';
 import { setupZodErrorMap } from '@/lib/zodErrorMap';
-import { useLanguage } from './useLanguage';
+import { useEffect } from 'react';
 
-export const useSyncZodErrorMap = () => {
-	const language = useLanguage((state) => state.language);
-
+export const useSetupZodErrorMap = () => {
 	useEffect(() => {
-		setupZodErrorMap(language);
-	}, [language]);
+		setupZodErrorMap();
+	}, []);
 };

--- a/src/lib/invoice-pdf/invoicePdfLocale.ts
+++ b/src/lib/invoice-pdf/invoicePdfLocale.ts
@@ -1,12 +1,12 @@
 import type { Country } from '@/db/tables/addressTableBase';
 import { getCountryDisplayName } from '@/lib/countries';
 import type { Language } from '@/hooks/use-language/types';
-import { getServerT } from '@/utils/languageUtils';
+import { createTranslationFunction } from '@/translations/translate';
 
 /** Invoice PDF copy is English-only; country names must not follow UI locale. */
 export const INVOICE_PDF_LANGUAGE = 'en' satisfies Language;
 
-const invoicePdfT = getServerT(INVOICE_PDF_LANGUAGE);
+const invoicePdfT = createTranslationFunction(INVOICE_PDF_LANGUAGE);
 
 export const getInvoicePdfCountryName = (countryCode: Country['code']) =>
 	getCountryDisplayName(invoicePdfT, countryCode);

--- a/src/lib/zodErrorMap.ts
+++ b/src/lib/zodErrorMap.ts
@@ -1,6 +1,5 @@
-import type { Language } from '@/hooks/use-language/types';
+import { getT } from '@/utils/languageUtils';
 import z from 'zod';
-import { translate } from '@/translations/translate';
 
 type ZodIssue = {
 	input?: unknown;
@@ -10,15 +9,17 @@ type ZodIssue = {
 	format?: unknown;
 };
 
-const getInvalidTypeMessage = (language: Language, issue: ZodIssue) => {
+const getInvalidTypeMessage = (issue: ZodIssue) => {
+	const t = getT();
+
 	if ('input' in issue && (issue.input === undefined || issue.input === null)) {
-		return translate(language, 'validation.required');
+		return t('validation.required');
 	}
 
-	return translate(language, 'validation.invalidType');
+	return t('validation.invalidType');
 };
 
-const getTooSmallMessage = (language: Language, issue: ZodIssue) => {
+const getTooSmallMessage = (issue: ZodIssue) => {
 	if (!('origin' in issue) || !('minimum' in issue)) {
 		return undefined;
 	}
@@ -38,30 +39,33 @@ const getTooSmallMessage = (language: Language, issue: ZodIssue) => {
 		return undefined;
 	}
 
+	const t = getT();
+
 	if (issue.origin === 'string' && minimum <= 1) {
-		return translate(language, 'validation.required');
+		return t('validation.required');
 	}
 
 	if (issue.origin === 'string') {
-		return translate(language, 'validation.minCharacters', {
+		return t('validation.minCharacters', {
 			minimum,
 		});
 	}
 
-	return translate(language, 'validation.minNumber', {
+	return t('validation.minNumber', {
 		minimum,
 	});
 };
 
-const getInvalidFormatMessage = (language: Language, issue: ZodIssue) => {
+const getInvalidFormatMessage = (issue: ZodIssue) => {
 	if (!('format' in issue) || issue.format !== 'email') {
 		return undefined;
 	}
+	const t = getT();
 
-	return translate(language, 'validation.invalidEmail');
+	return t('validation.invalidEmail');
 };
 
-const getTooBigMessage = (language: Language, issue: ZodIssue) => {
+const getTooBigMessage = (issue: ZodIssue) => {
 	if (!('origin' in issue) || !('maximum' in issue)) {
 		return undefined;
 	}
@@ -77,14 +81,16 @@ const getTooBigMessage = (language: Language, issue: ZodIssue) => {
 		return undefined;
 	}
 
+	const t = getT();
+
 	if (issue.origin === 'string') {
-		return translate(language, 'validation.maxCharacters', {
+		return t('validation.maxCharacters', {
 			maximum,
 		});
 	}
 
 	if (issue.origin === 'number') {
-		return translate(language, 'validation.maxNumber', {
+		return t('validation.maxNumber', {
 			maximum,
 		});
 	}
@@ -92,18 +98,18 @@ const getTooBigMessage = (language: Language, issue: ZodIssue) => {
 	return undefined;
 };
 
-export const setupZodErrorMap = (language: Language) => {
+export const setupZodErrorMap = () => {
 	z.config({
 		customError: (issue) => {
 			switch (issue.code) {
 				case 'invalid_type':
-					return getInvalidTypeMessage(language, issue);
+					return getInvalidTypeMessage(issue);
 				case 'too_small':
-					return getTooSmallMessage(language, issue);
+					return getTooSmallMessage(issue);
 				case 'too_big':
-					return getTooBigMessage(language, issue);
+					return getTooBigMessage(issue);
 				case 'invalid_format':
-					return getInvalidFormatMessage(language, issue);
+					return getInvalidFormatMessage(issue);
 				default:
 					return undefined;
 			}

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -1,6 +1,6 @@
 import { Toaster } from '@/components/toaster/Toaster';
 import { Tooltip } from '@/components/tooltip/Tooltip';
-import { useSyncZodErrorMap } from '@/hooks/use-language/useSyncZodErrorMap';
+import { useSetupZodErrorMap } from '@/hooks/use-language/useSyncZodErrorMap';
 import { useTranslate } from '@/hooks/use-translate/useTranslate';
 import { TanStackDevtools } from '@tanstack/react-devtools';
 import type { QueryClient } from '@tanstack/react-query';
@@ -38,7 +38,7 @@ function RootErrorComponent() {
 }
 
 function RootDocument({ children }: { children: React.ReactNode }) {
-	useSyncZodErrorMap();
+	useSetupZodErrorMap();
 
 	return (
 		<html

--- a/src/routes/_auth/app/contracts/-lib/contracts-upsert-form/contractsUpsertFormSchemas.ts
+++ b/src/routes/_auth/app/contracts/-lib/contracts-upsert-form/contractsUpsertFormSchemas.ts
@@ -1,7 +1,6 @@
 import { getEditContractQueryOptions } from '@/api/contract/getEditContract';
 import { addressFormWithCountrySchema } from '@/components/address-form/addressFormSchemas';
-import { translate } from '@/translations/translate';
-import { getLanguage } from '@/utils/languageUtils';
+import { getT } from '@/utils/languageUtils';
 import { useQuery } from '@tanstack/react-query';
 import z from 'zod';
 import {
@@ -37,11 +36,12 @@ const contractInvoiceRecurrenceFormSchema = z
 		const { totalPercentage } = getContractRecurrenceItemsTotalPercentage(
 			data.items,
 		);
+		const t = getT();
+
 		if (totalPercentage !== 100) {
 			ctx.addIssue({
 				code: 'custom',
-				message: translate(
-					getLanguage(),
+				message: t(
 					'contracts.form.invoiceRecurrence.validation.totalPercentageMustBe100',
 				),
 				path: ['items'],
@@ -54,8 +54,7 @@ const contractInvoiceRecurrenceFormSchema = z
 			for (const index of conflictingIndexes) {
 				ctx.addIssue({
 					code: 'custom',
-					message: translate(
-						getLanguage(),
+					message: t(
 						'contracts.form.invoiceRecurrence.validation.duplicateDayOfMonth',
 					),
 					path: ['items', index, 'dayOfMonth'],
@@ -75,12 +74,11 @@ const contractAutoSendFormSchema = z
 		}
 
 		if (!data.emailTemplateId.trim()) {
+			const t = getT();
+
 			ctx.addIssue({
 				code: 'custom',
-				message: translate(
-					getLanguage(),
-					'contracts.form.autoSend.validation.templateRequired',
-				),
+				message: t('contracts.form.autoSend.validation.templateRequired'),
 				path: ['emailTemplateId'],
 			});
 		}

--- a/src/routes/_auth/app/settings/-lib/settings-company-tab/companyUpsertFormSchemas.ts
+++ b/src/routes/_auth/app/settings/-lib/settings-company-tab/companyUpsertFormSchemas.ts
@@ -1,19 +1,10 @@
 import { addressFormSchema } from '@/components/address-form/addressFormSchemas';
 import { useCompany } from '@/hooks/use-company/useCompany';
-import { translate } from '@/translations/translate';
-import { getLanguage } from '@/utils/languageUtils';
 import z from 'zod';
 
-const requiredMessage = translate(getLanguage(), 'validation.required');
-const invalidEmailMessage = translate(getLanguage(), 'validation.invalidEmail');
-
 const generalFormSchema = z.object({
-	name: z.string().min(1, {
-		message: requiredMessage,
-	}),
-	email: z.email({
-		message: invalidEmailMessage,
-	}),
+	name: z.string().min(1),
+	email: z.email(),
 });
 
 export const companyUpsertFormSchema = z.object({

--- a/src/utils/languageUtils.ts
+++ b/src/utils/languageUtils.ts
@@ -1,17 +1,13 @@
 import type { Language } from '@/hooks/use-language/types';
 import { useLanguage } from '@/hooks/use-language/useLanguage';
-import { translate } from '@/translations/translate';
-import type {
-	TranslationFn,
-	TranslationKey,
-	TranslationRuntimeParams,
-} from '@/translations/types';
+import { createTranslationFunction } from '@/translations/translate';
+import type { TranslationFn } from '@/translations/types';
 import { createIsomorphicFn } from '@tanstack/react-start';
 import { getCookie } from '@tanstack/react-start/server';
 
 export const LANGUAGE_COOKIE_NAME = 'app_locale';
 
-const isLanguage = (value: string): value is Language => {
+export const isLanguage = (value: string): value is Language => {
 	return value === 'en' || value === 'br';
 };
 
@@ -23,17 +19,9 @@ const resolveLanguage = (languageCandidate: string | undefined): Language => {
 	return isLanguage(languageCandidate) ? languageCandidate : 'en';
 };
 
-export const getServerT = (language: Language): TranslationFn => {
-	const runTranslate = translate as (
-		language: Language,
-		path: TranslationKey,
-		params?: TranslationRuntimeParams,
-	) => string;
-
-	return ((...args: [TranslationKey, TranslationRuntimeParams?]) =>
-		runTranslate(language, args[0], args[1])) as TranslationFn;
-};
-
+/**
+ * Stateless language getter for use in server fns and outside of render cycles (e.g. zod schemas)
+ */
 export const getLanguage = createIsomorphicFn()
 	.client(() => {
 		const language = useLanguage.getState().language;
@@ -43,3 +31,11 @@ export const getLanguage = createIsomorphicFn()
 		const language = resolveLanguage(getCookie(LANGUAGE_COOKIE_NAME));
 		return language;
 	});
+
+/**
+ * Stateless translation function for use in server fns and outside of render cycles (e.g. zod schemas)
+ */
+export const getT = (): TranslationFn => {
+	const language = getLanguage();
+	return createTranslationFunction(language);
+};

--- a/src/utils/queryOptionsUtils.ts
+++ b/src/utils/queryOptionsUtils.ts
@@ -9,8 +9,7 @@ import type {
 } from '@tanstack/react-query';
 import type { SuccessResponse } from './serverFnsUtils';
 import { toast } from 'sonner';
-import { translate } from '@/translations/translate';
-import { getLanguage } from './languageUtils';
+import { getT } from './languageUtils';
 
 export type InvalidateOnSuccessArgs = Parameters<
 	NonNullable<MutationOptions<unknown, unknown, unknown>['onSuccess']>
@@ -50,8 +49,8 @@ const handleError = (error: unknown) => {
 	}
 
 	if (!message) {
-		const language = getLanguage();
-		message = translate(language, 'common.unknownError');
+		const t = getT();
+		message = t('common.unknownError');
 	}
 
 	toast.error(message);


### PR DESCRIPTION
…te()

Centralize locale-aware translations via getT() in server fns, Zod schemas, and query error handling; remove session language from context.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal localization system architecture for better performance and consistency across the application.
  * Simplified translation initialization across server functions and form validations.
  * Updated error map setup to initialize once at application startup rather than on every language change.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/invoiced-org-tbd/invoiced/pull/59?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->